### PR TITLE
corrects instruction for building the provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provi
 ```sh
 mkdir -p $GOPATH/src/github.com/terraform-providers
 cd $GOPATH/src/github.com/terraform-providers
-git clone git@github.com:terraform-providers/terraform-provider-linode
+git clone https://github.com/displague/terraform-provider-linode.git
 ```
 
 Enter the provider directory and build the provider


### PR DESCRIPTION
@displague : trying to build the provider with the current instructions in the README results in either permission errors (when attempting to git clone via ssh) or non-existing repo errors (when attempting to git clone via https). 

> This might be due to the repo (`terraform-providers/terraform-provider-linode`)  being private and thus available to only you/people with access to it. 

What worked for me was git clone your repo (not `terraform-providers/terraform-provider-linode`) via https.  The other alternative is to fork the repo (but this might be more appropriate for folks who intend to work/contribute). 