### PR TITLE
adds correct value of default swap_size

### DIFF
--- a/website/docs/r/instance.html.md
+++ b/website/docs/r/instance.html.md
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `disk_expansion` - (Optional) A boolean that when true will automatically expand the root volume if the size of the Linode plan is increased.  Setting this value will prevent downsizing without manually shrinking the volume prior to decreasing the size.
 
-* `swap_size` - (Optional) Sets the size of the swap partition on a Linode in MB.  At this time, this cannot be modified by Terraform after initial provisioning.  If manually modified via the Web GUI, this value will reflect such modification.  This value can be set to 0 to create a Linode without a swap partition.  Defaults to 256.
+* `swap_size` - (Optional) Sets the size of the swap partition on a Linode in MB.  At this time, this cannot be modified by Terraform after initial provisioning.  If manually modified via the Web GUI, this value will reflect such modification.  This value can be set to 0 to create a Linode without a swap partition.  Defaults to 512.
 
 ## Attributes
 


### PR DESCRIPTION
@displague 
1.  Current documentation for creating a Linode instance points to default swap_size of 256 (referencing what I believe was the default swap_size in v3 of LinodeApi).
    <img width="1062" alt="screen shot 2018-08-27 at 3 55 13 pm" src="https://user-images.githubusercontent.com/38335185/44683131-5e6b7000-aa13-11e8-9bd3-938644751c78.png">

2. This pull request corrects documentation for [creating a linode instance](https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/instance.html.md)  such that it matches the default swap_size to 512 as set in `resource_linode_instance.go:173` and in v4 of LinodeApi