### PR TITLE
use random root password if none provided

### DIFF
--- a/linode/linode_instance_helpers.go
+++ b/linode/linode_instance_helpers.go
@@ -2,6 +2,7 @@ package linode
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"log"
@@ -469,8 +470,14 @@ func createInstanceDisk(client linodego.Client, instance linodego.Instance, v in
 	if image, ok := disk["image"]; ok {
 		diskOpts.Image = image.(string)
 
-		if rootPass, ok := disk["root_pass"]; ok {
+		if rootPass, ok := disk["root_pass"]; ok && rootPass != "" {
 			diskOpts.RootPass = rootPass.(string)
+		} else {
+			var err error
+			diskOpts.RootPass, err = createRandomRootPassword()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if authorizedKeys, ok := disk["authorized_keys"]; ok {
@@ -649,6 +656,16 @@ func rootPasswordState(val interface{}) string {
 func hashString(key string) string {
 	hash := sha3.Sum512([]byte(key))
 	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+func createRandomRootPassword() (string, error) {
+	rawRootPass := make([]byte, 50)
+	_, err := rand.Read(rawRootPass)
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate random password")
+	}
+	rootPass := base64.StdEncoding.EncodeToString(rawRootPass)
+	return rootPass, nil
 }
 
 // changeInstanceType resizes the Linode Instance

--- a/linode/resource_linode_instance.go
+++ b/linode/resource_linode_instance.go
@@ -827,6 +827,13 @@ func resourceLinodeInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 			createOpts.AuthorizedKeys = append(createOpts.AuthorizedKeys, key.(string))
 		}
 		createOpts.RootPass = d.Get("root_pass").(string)
+		if createOpts.RootPass == "" {
+			var err error
+			createOpts.RootPass, err = createRandomRootPassword()
+			if err != nil {
+				return err
+			}
+		}
 		createOpts.Image = d.Get("image").(string)
 		createOpts.Booted = &boolTrue
 		createOpts.BackupID = d.Get("backup_id").(int)


### PR DESCRIPTION
This replaces #17 ; it's updated w/ the revamp of the Instance object, and works by using a random password in cases where no `root_pass` is set.