### PR TITLE
initial support for Linode SSH Keys (linode_sshkey)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See the docs included in the website/docs directory:
 - <https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/nodebalancer.html.md>
 - <https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/nodebalancer_config.html.md>
 - <https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/nodebalancer_node.html.md>
+- <https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/sshkey.html.md>
 - <https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/stackscript.html.md>
 - <https://github.com/displague/terraform-provider-linode/blob/master/website/docs/r/volume.html.md>
 

--- a/linode/provider.go
+++ b/linode/provider.go
@@ -33,6 +33,7 @@ func Provider() terraform.ResourceProvider {
 			"linode_nodebalancer_config": resourceLinodeNodeBalancerConfig(),
 			"linode_nodebalancer_node":   resourceLinodeNodeBalancerNode(),
 			"linode_volume":              resourceLinodeVolume(),
+			"linode_sshkey":              resourceLinodeSSHKey(),
 			"linode_stackscript":         resourceLinodeStackscript(),
 		},
 

--- a/linode/resource_linode_sshkey.go
+++ b/linode/resource_linode_sshkey.go
@@ -1,0 +1,147 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/linode/linodego"
+)
+
+func resourceLinodeSSHKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLinodeSSHKeyCreate,
+		Read:   resourceLinodeSSHKeyRead,
+		Update: resourceLinodeSSHKeyUpdate,
+		Delete: resourceLinodeSSHKeyDelete,
+		Exists: resourceLinodeSSHKeyExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"label": {
+				Type:        schema.TypeString,
+				Description: "The label of the Linode SSH Key.",
+				Required:    true,
+			},
+			"ssh_key": {
+				Type:        schema.TypeString,
+				Description: "The public SSH Key, which is used to authenticate to the root user of the Linodes you deploy.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"created": {
+				Type:        schema.TypeString,
+				Description: "The date this key was added.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceLinodeSSHKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(linodego.Client)
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("Error parsing Linode SSH Key ID %s as int: %s", d.Id(), err)
+	}
+
+	_, err = client.GetSSHKey(context.Background(), int(id))
+	if err != nil {
+		if lerr, ok := err.(*linodego.Error); ok && lerr.Code == 404 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return false, fmt.Errorf("Error getting Linode SSH Key ID %s: %s", d.Id(), err)
+	}
+	return true, nil
+}
+
+func resourceLinodeSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error parsing Linode SSH Key ID %s as int: %s", d.Id(), err)
+	}
+
+	sshkey, err := client.GetSSHKey(context.Background(), int(id))
+
+	if err != nil {
+		return fmt.Errorf("Error finding the specified Linode SSH Key: %s", err)
+	}
+
+	d.Set("label", sshkey.Label)
+	d.Set("ssh_key", sshkey.SSHKey)
+	if sshkey.Created != nil {
+		d.Set("created", sshkey.Created.Format(time.RFC3339))
+	}
+
+	return nil
+}
+
+func resourceLinodeSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	client, ok := meta.(linodego.Client)
+	if !ok {
+		return fmt.Errorf("Invalid Client when creating Linode SSH Key")
+	}
+
+	createOpts := linodego.SSHKeyCreateOptions{
+		Label:  d.Get("label").(string),
+		SSHKey: d.Get("ssh_key").(string),
+	}
+	sshkey, err := client.CreateSSHKey(context.Background(), createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating a Linode SSH Key: %s", err)
+	}
+	d.SetId(fmt.Sprintf("%d", sshkey.ID))
+	d.Set("label", sshkey.Label)
+	d.Set("ssh_key", sshkey.SSHKey)
+	if sshkey.Created != nil {
+		d.Set("created", sshkey.Created.Format(time.RFC3339))
+	}
+
+	return resourceLinodeSSHKeyRead(d, meta)
+}
+
+func resourceLinodeSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error parsing Linode SSH Key id %s as int: %s", d.Id(), err)
+	}
+
+	if d.HasChange("label") {
+		sshkey, err := client.GetSSHKey(context.Background(), int(id))
+
+		updateOpts := sshkey.GetUpdateOptions()
+		updateOpts.Label = d.Get("label").(string)
+
+		if err != nil {
+			return fmt.Errorf("Error fetching data about the current Linode SSH Key: %s", err)
+		}
+
+		if sshkey, err = client.UpdateSSHKey(context.Background(), int(id), updateOpts); err != nil {
+			return err
+		}
+		d.Set("label", sshkey.Label)
+	}
+
+	return resourceLinodeSSHKeyRead(d, meta)
+}
+
+func resourceLinodeSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(linodego.Client)
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error parsing Linode SSH Key id %s as int", d.Id())
+	}
+	err = client.DeleteSSHKey(context.Background(), int(id))
+	if err != nil {
+		return fmt.Errorf("Error deleting Linode SSH Key %d: %s", id, err)
+	}
+	return nil
+}

--- a/linode/resource_linode_sshkey_test.go
+++ b/linode/resource_linode_sshkey_test.go
@@ -1,0 +1,159 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/linode/linodego"
+)
+
+func TestAccLinodeSSHKey_basic(t *testing.T) {
+	t.Parallel()
+
+	resName := "linode_sshkey.foobar"
+	var sshkeyName = acctest.RandomWithPrefix("tf_test")
+	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("linode@ssh-acceptance-test")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeSSHKeyConfigBasic(sshkeyName, publicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeSSHKeyExists,
+					resource.TestCheckResourceAttr(resName, "label", sshkeyName),
+					resource.TestCheckResourceAttr(resName, "ssh_key", publicKeyMaterial),
+					resource.TestCheckResourceAttrSet(resName, "created"),
+				),
+			},
+
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLinodeSSHKey_update(t *testing.T) {
+	t.Parallel()
+	resName := "linode_sshkey.foobar"
+	var sshkeyName = acctest.RandomWithPrefix("tf_test")
+	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("linode@ssh-acceptance-test")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLinodeSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLinodeSSHKeyConfigBasic(sshkeyName, publicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeSSHKeyExists,
+					resource.TestCheckResourceAttr(resName, "label", sshkeyName),
+					resource.TestCheckResourceAttr(resName, "ssh_key", publicKeyMaterial),
+					resource.TestCheckResourceAttrSet(resName, "created"),
+				),
+			},
+			{
+				Config: testAccCheckLinodeSSHKeyConfigUpdates(sshkeyName, publicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinodeSSHKeyExists,
+					resource.TestCheckResourceAttr(resName, "label", fmt.Sprintf("%s_renamed", sshkeyName)),
+					resource.TestCheckResourceAttr(resName, "ssh_key", publicKeyMaterial),
+					resource.TestCheckResourceAttrSet(resName, "created"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckLinodeSSHKeyExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(linodego.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "linode_sshkey" {
+			continue
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error parsing %v to int", rs.Primary.ID)
+		}
+
+		_, err = client.GetSSHKey(context.Background(), id)
+		if err != nil {
+			return fmt.Errorf("Error retrieving state of SSHKey %s: %s", rs.Primary.Attributes["label"], err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckLinodeSSHKeyDestroy(s *terraform.State) error {
+	client, ok := testAccProvider.Meta().(linodego.Client)
+	if !ok {
+		return fmt.Errorf("Error getting Linode client")
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "linode_sshkey" {
+			continue
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error parsing %v to int", rs.Primary.ID)
+		}
+		if id == 0 {
+			return fmt.Errorf("Would have considered %v as %d", rs.Primary.ID, id)
+
+		}
+
+		_, err = client.GetSSHKey(context.Background(), id)
+
+		if err == nil {
+			return fmt.Errorf("Linode SSH Key with id %d still exists", id)
+		}
+
+		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code != 404 {
+			return fmt.Errorf("Error requesting Linode SSH Key with id %d", id)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckLinodeSSHKeyConfigBasic(label, sshkey string) string {
+	return fmt.Sprintf(`
+resource "linode_sshkey" "foobar" {
+	label = "%s"
+	ssh_key = "%s"
+}`, label, sshkey)
+}
+
+func testAccCheckLinodeSSHKeyConfigUpdates(label, sshkey string) string {
+	return fmt.Sprintf(`
+resource "linode_sshkey" "foobar" {
+	label = "%s_renamed"
+	ssh_key = "%s"
+}`, label, sshkey)
+}

--- a/linode/resource_linode_template.go
+++ b/linode/resource_linode_template.go
@@ -111,7 +111,7 @@ func resourceLinodeTemplateUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	template, err := client.GetTemplate(int(id))
 	if err != nil {
-		return fmt.Errorf("Error fetching data about the current linode: %s", err)
+		return fmt.Errorf("Error fetching data about the current Linode Template: %s", err)
 	}
 
 	if d.HasChange("label") {
@@ -121,7 +121,7 @@ func resourceLinodeTemplateUpdate(d *schema.ResourceData, meta interface{}) erro
 		d.Set("label", template.Label)
 	}
 
-	return nil // resourceLinodeTemplateRead(d, meta)
+	return resourceLinodeTemplateRead(d, meta)
 }
 
 func resourceLinodeTemplateDelete(d *schema.ResourceData, meta interface{}) error {

--- a/linode/resource_linode_template_test.go
+++ b/linode/resource_linode_template_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/linode/linodego"
 )
 
-func TestAccLinodeTemplateBasic(t *testing.T) {
+func TestAccLinodeTemplate_basic(t *testing.T) {
 	t.Parallel()
 
 	resName := "linode_template.foobar"
@@ -24,15 +24,14 @@ func TestAccLinodeTemplateBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLinodeTemplateDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckLinodeTemplateConfigBasic(templateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeTemplateExists,
 					resource.TestCheckResourceAttr(resName, "label", templateName),
 				),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -41,28 +40,29 @@ func TestAccLinodeTemplateBasic(t *testing.T) {
 	})
 }
 
-func TestAccLinodeTemplateUpdate(t *testing.T) {
+func TestAccLinodeTemplate_update(t *testing.T) {
 	t.Parallel()
 
 	var templateName = acctest.RandomWithPrefix("tf_test")
+	resName := "linode_template.foobar"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLinodeTemplateDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckLinodeTemplateConfigBasic(templateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeTemplateExists,
-					resource.TestCheckResourceAttr("linode_template.foobar", "label", templateName),
+					resource.TestCheckResourceAttr(resName, "label", templateName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckLinodeTemplateConfigUpdates(templateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinodeTemplateExists,
-					resource.TestCheckResourceAttr("linode_template.foobar", "label", fmt.Sprintf("%s_renamed", templateName)),
+					resource.TestCheckResourceAttr(resName, "label", fmt.Sprintf("%s_renamed", templateName)),
 				),
 			},
 		},

--- a/website/docs/r/sshkey.html.md
+++ b/website/docs/r/sshkey.html.md
@@ -1,0 +1,55 @@
+---
+layout: "linode"
+page_title: "Linode: linode_sshkey"
+sidebar_current: "docs-linode-resource-sshkey"
+description: |-
+  Manages a Linode SSH Key.
+---
+
+# linode\_sshkey
+
+Provides a Linode SSH Key resource.  This can be used to create, modify, and delete Linodes sshkeys.
+For more information, see the [Linode APIv4 docs](https://developers.linode.com/api/v4#operation/getSSHKeys).
+
+## Example Usage
+
+The following example shows how one might use this resource to configure a SSH Key for access to a Linode Instance.
+
+```hcl
+resource "linode_sshkey" "foo" {
+  label = "foo"
+  ssh_key = "${chomp(file("~/.ssh/id_rsa.pub"))}"
+}
+
+resource "linode_instance" "foo" {
+  image  = "linode/ubuntu18.04"
+  label  = "foo"
+  region = "us-east"
+  type   = "g6-nanode-1"
+  authorized_keys    = ["${linode_sshkey.foo.ssh_key}"]
+  root_pass      = "..."
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `label` - A label for the SSH Key.
+
+* `ssh_key` - The public SSH Key, which is used to authenticate to the root user of the Linodes you deploy.
+
+
+## Attributes
+
+This resource exports the following attributes:
+
+* `created` - The date this SSH Key was created.
+
+## Import
+
+Linodes SSH Keys can be imported using the Linode SSH Key `id`, e.g.
+
+```sh
+terraform import linode_sshkey.mysshkey 1234567
+```

--- a/website/linode.erb
+++ b/website/linode.erb
@@ -31,6 +31,9 @@
             <li<%= sidebar_current("docs-linode-resource-nodebalancer_node") %>>
               <a href="/docs/providers/linode/r/nodebalancer_node.html">linode_nodebalancer_node</a>
             </li>
+            <li<%= sidebar_current("docs-linode-resource-sshkey") %>>
+              <a href="/docs/providers/linode/r/sshkey.html">linode_sshkey</a>
+            </li>
             <li<%= sidebar_current("docs-linode-resource-stackscript") %>>
               <a href="/docs/providers/linode/r/stackscript.html">linode_stackscript</a>
             </li>


### PR DESCRIPTION
Adds support for managing Linode SSH Key resources.

```hcl
resource "linode_sshkey" "foo" {
  label = "foo"
  ssh_key = "${chomp(file("~/.ssh/id_rsa.pub"))}"
}
resource "linode_instance" "foo" {
  image  = "linode/ubuntu18.04"
  label  = "foo"
  region = "us-east"
  type   = "g6-nanode-1"
  authorized_keys    = ["${linode_sshkey.foo.ssh_key}"]
  root_pass      = "..."
}
```